### PR TITLE
Fix/Threaded Operations

### DIFF
--- a/Unikeys.Gui/App.xaml
+++ b/Unikeys.Gui/App.xaml
@@ -30,6 +30,10 @@
                             <system:Uri x:Key="TrashIcon">/Icons/Light/trash-black.svg</system:Uri>
                             <system:Uri x:Key="WritingSignatureIcon">/Icons/Light/writing-sign-black.svg</system:Uri>
                             <!--  ReSharper restore Xaml.ConstructorWarning  -->
+
+                            <Brush x:Key="InvertedForegroundColor">
+                                Black
+                            </Brush>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="Dark">
                             <!--  ReSharper disable Xaml.ConstructorWarning  -->
@@ -51,6 +55,10 @@
                             <system:Uri x:Key="TrashIcon">/Icons/Dark/trash-white.svg</system:Uri>
                             <system:Uri x:Key="WritingSignatureIcon">/Icons/Dark/writing-sign-white.svg</system:Uri>
                             <!--  ReSharper restore Xaml.ConstructorWarning  -->
+
+                            <Brush x:Key="InvertedForegroundColor">
+                                White
+                            </Brush>
                         </ResourceDictionary>
                     </ui:ThemeResources.ThemeDictionaries>
                 </ui:ThemeResources>

--- a/Unikeys.Gui/AssemblyInfo.cs
+++ b/Unikeys.Gui/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Resources;
 using System.Windows;
 
 [assembly: ThemeInfo(
@@ -10,4 +11,4 @@ using System.Windows;
     // app, or any theme specific resource dictionaries)
 )]
 // The program will pull this version to display in the "About" tab
-[assembly: AssemblyVersion("1.1.1.*")]
+[assembly: AssemblyVersion("1.1.2.*")]

--- a/Unikeys.Gui/Tabs/DecryptTab.xaml
+++ b/Unikeys.Gui/Tabs/DecryptTab.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:svgc="http://sharpvectors.codeplex.com/svgc/"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
     d:DesignHeight="300"
     d:DesignWidth="300"
     TextElement.FontFamily="{StaticResource Roboto}"
@@ -67,12 +68,22 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Center"
             Click="DecryptButton_OnClick">
-            <StackPanel Margin="0,3" Orientation="Horizontal">
-                <svgc:SvgViewbox MaxHeight="19" Source="{DynamicResource KeyIcon}"/>
-                <Label Margin="5,0,0,0" FontFamily="{StaticResource Roboto}">
-                    Decrypt selected file
-                </Label>
-            </StackPanel>
+            <Grid>
+                <StackPanel
+                    x:Name="DecryptButtonContent"
+                    Margin="0,3"
+                    Orientation="Horizontal">
+                    <svgc:SvgViewbox MaxHeight="19" Source="{DynamicResource KeyIcon}"/>
+                    <Label Margin="5,0,0,0" FontFamily="{StaticResource Roboto}">
+                        Decrypt selected file
+                    </Label>
+                </StackPanel>
+                <ui:ProgressRing
+                    x:Name="ProgressIndicator"
+                    Foreground="{DynamicResource InvertedForegroundColor}"
+                    IsActive="True"
+                    Visibility="Collapsed"/>
+            </Grid>
         </Button>
     </Grid>
 </UserControl>

--- a/Unikeys.Gui/Tabs/DecryptTab.xaml.cs
+++ b/Unikeys.Gui/Tabs/DecryptTab.xaml.cs
@@ -122,5 +122,9 @@ public partial class DecryptTab
         PasswordInputBox.IsEnabled = !locked;
         ChooseFileButton.IsEnabled = !locked;
         DecryptButton.IsEnabled = !locked;
+
+        // Shows a loading animation while the decryption is in progress
+        DecryptButtonContent.Visibility = locked ? Visibility.Collapsed : Visibility.Visible;
+        ProgressIndicator.Visibility = locked ? Visibility.Visible : Visibility.Collapsed;
     }
 }

--- a/Unikeys.Gui/Tabs/DecryptTab.xaml.cs
+++ b/Unikeys.Gui/Tabs/DecryptTab.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Win32;
 using Unikeys.Core.FileEncryption;
@@ -37,7 +38,7 @@ public partial class DecryptTab
     /// <summary>
     /// Decrypts the file with the specified password
     /// </summary>
-    private void DecryptButton_OnClick(object sender, RoutedEventArgs e)
+    private async void DecryptButton_OnClick(object sender, RoutedEventArgs e)
     {
         // Check if a file is selected
         if (_filePath == "")
@@ -88,7 +89,7 @@ public partial class DecryptTab
         LockDecryptionGui(true);
         try
         {
-            Decryption.DecryptFile(_filePath, dialog.FileName, PasswordInputBox.Password);
+            await Task.Run(() => Decryption.DecryptFile(_filePath, dialog.FileName, PasswordInputBox.Password));
         }
         catch (Exception ex)
         {

--- a/Unikeys.Gui/Tabs/EncryptTab.xaml
+++ b/Unikeys.Gui/Tabs/EncryptTab.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:svgc="http://sharpvectors.codeplex.com/svgc/"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
     d:DesignHeight="300"
     d:DesignWidth="300"
     TextElement.FontFamily="{StaticResource Roboto}"
@@ -78,15 +79,25 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Center"
             Click="EncryptButton_OnClick">
-            <StackPanel Margin="0,3" Orientation="Horizontal">
-                <svgc:SvgViewbox MaxHeight="19" Source="{DynamicResource KeyIcon}"/>
-                <Label
-                    Margin="5,0,0,0"
-                    HorizontalAlignment="Center"
-                    FontFamily="{StaticResource Roboto}">
-                    Encrypt selected file
-                </Label>
-            </StackPanel>
+            <Grid>
+                <StackPanel
+                    x:Name="EncryptButtonContent"
+                    Margin="0,3"
+                    Orientation="Horizontal">
+                    <svgc:SvgViewbox MaxHeight="19" Source="{DynamicResource KeyIcon}"/>
+                    <Label
+                        Margin="5,0,0,0"
+                        HorizontalAlignment="Center"
+                        FontFamily="{StaticResource Roboto}">
+                        Encrypt selected file
+                    </Label>
+                </StackPanel>
+                <ui:ProgressRing
+                    x:Name="ProgressIndicator"
+                    Foreground="{DynamicResource InvertedForegroundColor}"
+                    IsActive="True"
+                    Visibility="Collapsed"/>
+            </Grid>
         </Button>
     </Grid>
 </UserControl>

--- a/Unikeys.Gui/Tabs/EncryptTab.xaml.cs
+++ b/Unikeys.Gui/Tabs/EncryptTab.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Win32;
 using Unikeys.Core.FileEncryption;
@@ -47,7 +48,7 @@ public partial class EncryptTab
     /// <summary>
     /// Encrypts the file with the specified password
     /// </summary>
-    private void EncryptButton_OnClick(object sender, RoutedEventArgs e)
+    private async void EncryptButton_OnClick(object sender, RoutedEventArgs e)
     {
         // Check if a file has been chosen
         if (_filePath == "")
@@ -91,13 +92,14 @@ public partial class EncryptTab
         LockEncryptionGui(true);
         try
         {
-            key = Encryption.EncryptFile(_filePath, dialog.FileName, PasswordInputBox.Password);
+            await Task.Run(() => key = Encryption.EncryptFile(_filePath, dialog.FileName, PasswordInputBox.Password));
         }
         catch (Exception exception)
         {
             new CustomMessageBox(
                 "Oops...", "Something went wrong during encryption", CustomMessageBox.CustomMessageBoxIcons.Error,
                 exception).Show();
+            return;
         }
         finally
         {

--- a/Unikeys.Gui/Tabs/EncryptTab.xaml.cs
+++ b/Unikeys.Gui/Tabs/EncryptTab.xaml.cs
@@ -130,5 +130,9 @@ public partial class EncryptTab
         PasswordInputBox.IsEnabled = !locked;
         ChooseFileButton.IsEnabled = !locked;
         EncryptButton.IsEnabled = !locked;
+
+        // Show a loading animation while the encryption is in progress
+        EncryptButtonContent.Visibility = locked ? Visibility.Collapsed : Visibility.Visible;
+        ProgressIndicator.Visibility = locked ? Visibility.Visible : Visibility.Collapsed;
     }
 }

--- a/Unikeys.Gui/Tabs/ShredTab.xaml
+++ b/Unikeys.Gui/Tabs/ShredTab.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:svgc="http://sharpvectors.codeplex.com/svgc/"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
     d:DesignHeight="300"
     d:DesignWidth="300"
     TextElement.FontFamily="{StaticResource Roboto}"
@@ -57,12 +58,22 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Center"
             Click="ShredButton_OnClick">
-            <StackPanel Margin="0,3" Orientation="Horizontal">
-                <svgc:SvgViewbox MaxHeight="19" Source="{DynamicResource TrashIcon}"/>
-                <Label Margin="5,0,0,0" FontFamily="{StaticResource Roboto}">
-                    Shred selected files
-                </Label>
-            </StackPanel>
+            <Grid>
+                <StackPanel
+                    x:Name="ShredButtonContent"
+                    Margin="0,3"
+                    Orientation="Horizontal">
+                    <svgc:SvgViewbox MaxHeight="19" Source="{DynamicResource TrashIcon}"/>
+                    <Label Margin="5,0,0,0" FontFamily="{StaticResource Roboto}">
+                        Shred selected files
+                    </Label>
+                </StackPanel>
+                <ui:ProgressRing
+                    x:Name="ProgressIndicator"
+                    Foreground="{DynamicResource InvertedForegroundColor}"
+                    IsActive="True"
+                    Visibility="Collapsed"/>
+            </Grid>
         </Button>
     </Grid>
 </UserControl>

--- a/Unikeys.Gui/Tabs/ShredTab.xaml.cs
+++ b/Unikeys.Gui/Tabs/ShredTab.xaml.cs
@@ -84,5 +84,10 @@ public partial class ShredTab
     {
         ChooseFilesButton.IsEnabled = !locked;
         ShredButton.IsEnabled = !locked;
+        FileListView.IsEnabled = !locked;
+
+        // Show a loading animation while shredding
+        ShredButtonContent.Visibility = locked ? Visibility.Collapsed : Visibility.Visible;
+        ProgressIndicator.Visibility = locked ? Visibility.Visible : Visibility.Collapsed;
     }
 }

--- a/Unikeys.Gui/Tabs/ShredTab.xaml.cs
+++ b/Unikeys.Gui/Tabs/ShredTab.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Win32;
 using Unikeys.Core.FileShredding;
@@ -56,7 +57,7 @@ public partial class ShredTab
         try
         {
             var filesToShred = files.Select(f => new FileInfo(f));
-            await SDelete.DeleteFiles(filesToShred);
+            await Task.Run(() => SDelete.DeleteFiles(filesToShred));
         }
         catch (Exception exception)
         {


### PR DESCRIPTION
This PR now makes heavy operations (encryption, decryption, shredding) run on another thread to not block the GUI thread and to not cause a crash when clicking on the window while a heavy operation was in progress. This issue was only a problem for big files (100Mb+).
It also adds a cool progress ring in the button while an operation is running.